### PR TITLE
(GH-4)(GH-5) Complete help text and add --sitedir option

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+index.js
+dns.js
+test.js

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ require('yargs').command('set [script]', 'Set up site config', (yargs) => {
 		script: false,
 		siteName: 'mysite'
 	}
-	
+
 	if(argv.script) {
 		config.script = argv.script
 	}
@@ -32,7 +32,7 @@ require('yargs').command('set [script]', 'Set up site config', (yargs) => {
 	}
 
 	fs.writeFileSync(path.join(require('os').homedir(), '.localhost/sites', `${config.siteName}.json`), JSON.stringify(config))
-	
+
 	console.log(config)
 }).argv
 
@@ -57,7 +57,7 @@ require('yargs').command('run [site]', 'Run development site', (yargs) => {
 	env = process.env
 
 	env.PORT = await getPort({port: config.port})
-	
+
 	const subprocess = spawn(scriptName, args, {
 		cwd: config.path,
 		env
@@ -70,7 +70,7 @@ require('yargs').command('run [site]', 'Run development site', (yargs) => {
 	subprocess.stdout.on('data', (data) => {
 		console.log(data.toString());
 	});
-	
+
 	subprocess.stderr.on('data', (data) => {
 		console.error(`stderr: ${data}`);
 	});
@@ -94,7 +94,7 @@ require('yargs').command('tunnel [site]', 'Start Dev site tunnel', (yargs) => {
 
 	const config = JSON.parse(fs.readFileSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`))),
 	port = config.port
-	
+
 	const subprocess = spawn("tunnelto", ['--port', port, '--subdomain', argv.site], {
 		cwd: config.path
 	})
@@ -106,7 +106,7 @@ require('yargs').command('tunnel [site]', 'Start Dev site tunnel', (yargs) => {
 	subprocess.stdout.on('data', (data) => {
 		console.log(data.toString());
 	});
-	
+
 	subprocess.stderr.on('data', (data) => {
 		console.error(`stderr: ${data}`);
 	});

--- a/index.js
+++ b/index.js
@@ -5,110 +5,117 @@ path = require('path'),
 { spawn } = require('child_process'),
 getPort = require('get-port');
 
-require('yargs').scriptName("localhost");
+require('yargs')
+	.scriptName("localhost")
+	.command('set [script] [site]', 'Set up site config', (yargs) => {
+		yargs
+			.positional('script', {
+				describe: 'script to run',
+				default: 'npm start'
+			})
+			.positional("site", {
+				describe: "Name of the site to configure",
+				default: "mysite",
+				type: "string",
+			});
+	}, (argv) => {
+		let config = {
+			path: process.cwd(),
+			script: false,
+			siteName: 'mysite'
+		}
 
-require('yargs').command('set [script]', 'Set up site config', (yargs) => {
-	yargs.positional('script', {
-		describe: 'script to run',
-		default: 'npm start'
+		if(argv.script) {
+			config.script = argv.script
+		}
+
+		if(argv.site) {
+			config.siteName = argv.site
+		}
+
+		if(argv.port) {
+			config.port = argv.port
+		}
+
+		fs.writeFileSync(path.join(require('os').homedir(), '.localhost/sites', `${config.siteName}.json`), JSON.stringify(config))
+
+		console.log(config)
 	})
-}, (argv) => {
-	let config = {
-		path: process.cwd(),
-		script: false,
-		siteName: 'mysite'
-	}
+	.command('run [site]', 'Run development site', (yargs) => {
+		// TODO: If site is required, then shouldn't it be a required yarg parameter? i.e. <site>
+		yargs.positional('site', {
+			describe: 'Name of site to start'
+		})
+	}, async (argv) => {
+		if(!argv.site) {
+			console.log(`Whoops, looks like you forgot the site name. We need to know what site you're running`)
+			return
+		}
 
-	if(argv.script) {
-		config.script = argv.script
-	}
+		if(!(fs.existsSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`)))) {
+			console.log(`Looks like that site doesn't have a config file. Try running localhost set to add the config details`)
+			return
+		}
 
-	if(argv.site) {
-		config.siteName = argv.site
-	}
+		const config = JSON.parse(fs.readFileSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`))),
+		script = config.script.split(' '),
+		[scriptName, ...args] = script,
+		env = process.env
 
-	if(argv.port) {
-		config.port = argv.port
-	}
+		env.PORT = await getPort({port: config.port})
 
-	fs.writeFileSync(path.join(require('os').homedir(), '.localhost/sites', `${config.siteName}.json`), JSON.stringify(config))
+		const subprocess = spawn(scriptName, args, {
+			cwd: config.path,
+			env
+		})
 
-	console.log(config)
-}).argv
+		subprocess.on('error', (err) => {
+			console.error(err)
+		})
 
-require('yargs').command('run [site]', 'Run development site', (yargs) => {
-	yargs.positional('site', {
-		describe: 'Name of site to start'
+		subprocess.stdout.on('data', (data) => {
+			console.log(data.toString());
+		});
+
+		subprocess.stderr.on('data', (data) => {
+			console.error(`stderr: ${data}`);
+		});
 	})
-}, async (argv) => {
-	if(!argv.site) {
-		console.log(`Whoops, looks like you forgot the site name. We need to know what site you're running`)
-		return
-	}
+	.command('tunnel [site]', 'Start Dev site tunnel', (yargs) => {
+		// TODO: If site is required, then shouldn't it be a required yarg parameter? i.e. <site>
+		yargs.positional('site', {
+			describe: 'Name of site to start'
+		})
+	}, async (argv) => {
+		if(!argv.site) {
+			console.log(`Whoops, looks like you forgot the site name. We need to know what site you're running`)
+			return
+		}
 
-	if(!(fs.existsSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`)))) {
-		console.log(`Looks like that site doesn't have a config file. Try running localhost set to add the config details`)
-		return
-	}
+		if(!(fs.existsSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`)))) {
+			console.log(`Looks like that site doesn't have a config file. Try running localhost set to add the config details`)
+			return
+		}
 
-	const config = JSON.parse(fs.readFileSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`))),
-	script = config.script.split(' '),
-	[scriptName, ...args] = script,
-	env = process.env
+		const config = JSON.parse(fs.readFileSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`))),
+		port = config.port
 
-	env.PORT = await getPort({port: config.port})
+		const subprocess = spawn("tunnelto", ['--port', port, '--subdomain', argv.site], {
+			cwd: config.path
+		})
 
-	const subprocess = spawn(scriptName, args, {
-		cwd: config.path,
-		env
+		subprocess.on('error', (err) => {
+			console.error(err)
+		})
+
+		subprocess.stdout.on('data', (data) => {
+			console.log(data.toString());
+		});
+
+		subprocess.stderr.on('data', (data) => {
+			console.error(`stderr: ${data}`);
+		});
 	})
-
-	subprocess.on('error', (err) => {
-		console.error(err)
-	})
-
-	subprocess.stdout.on('data', (data) => {
-		console.log(data.toString());
-	});
-
-	subprocess.stderr.on('data', (data) => {
-		console.error(`stderr: ${data}`);
-	});
-
-}).argv
-
-require('yargs').command('tunnel [site]', 'Start Dev site tunnel', (yargs) => {
-	yargs.positional('site', {
-		describe: 'Name of site to start'
-	})
-}, async (argv) => {
-	if(!argv.site) {
-		console.log(`Whoops, looks like you forgot the site name. We need to know what site you're running`)
-		return
-	}
-
-	if(!(fs.existsSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`)))) {
-		console.log(`Looks like that site doesn't have a config file. Try running localhost set to add the config details`)
-		return
-	}
-
-	const config = JSON.parse(fs.readFileSync(path.join(require('os').homedir(), '.localhost/sites', `${argv.site}.json`))),
-	port = config.port
-
-	const subprocess = spawn("tunnelto", ['--port', port, '--subdomain', argv.site], {
-		cwd: config.path
-	})
-
-	subprocess.on('error', (err) => {
-		console.error(err)
-	})
-
-	subprocess.stdout.on('data', (data) => {
-		console.log(data.toString());
-	});
-
-	subprocess.stderr.on('data', (data) => {
-		console.error(`stderr: ${data}`);
-	});
-
-}).argv
+	.demandCommand(1, "You need at least one command")
+	.help()
+	.argv;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ path = require('path'),
 { spawn } = require('child_process'),
 getPort = require('get-port');
 
+require('yargs').scriptName("localhost");
+
 require('yargs').command('set [script]', 'Set up site config', (yargs) => {
 	yargs.positional('script', {
 		describe: 'script to run',


### PR DESCRIPTION
Builds on PR #3

Fixes #4 #5 

Previously running localhost --help would only show the run command. Even
running localhost by itself would not show any output.  This commit:

* Modifies the call chain for yargs so that the additional commands appear in
  the help output
* Adds a demand for a minimum of 1 command. So that when running the bare
  command `localhost` now generates the command help
* Adds the sitename to the `set` command description so that it appears in the
  command help

---

Previously the site configuration directory must always be in the users home
directory, however there may be cases where users may want to use a non-default
location, specifically for the unit/integration testing of this project.

This commit adds a `sitedir` option to all commands and sets the default to the
previous value of '~/.localhost/sites'.