### PR TITLE
(GH-10) Add GitHub actions to exercise unit tests

### DIFF
--- a/.github/workflows/localhost-ci.yml
+++ b/.github/workflows/localhost-ci.yml
@@ -1,0 +1,35 @@
+name: localhost-ci
+
+on:
+  pull_request:
+    branches:
+      - prod
+  push:
+    branches:
+      - prod
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [10]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: 'setup node: ${{ matrix.node-version }} platform: ${{ matrix.os }}'
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install with Yarn
+        run: yarn install
+
+      - name: Install localhost
+        run: |
+          npm link;
+          yarn link
+
+      - name: Run Tests
+        run: yarn run test


### PR DESCRIPTION
Fixes #10 

In commit 80100e7c unit tests were added.  This commit adds a GitHub Actions
file which will run the tests on merge to `prod` and any Pull Requests against
the `prod` branch.